### PR TITLE
add export statement to shell profiles

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -70,6 +70,17 @@ function installNVM {
 
   export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+
+
+      echo '
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh”
+  ' >> ~/.bash_profile
+
+      echo '
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh”
+    ' >> ~/.zshrc
 }
 
 function installNode {


### PR DESCRIPTION
Is this a good idea? It will add to/create both a `.zshrc` and a `.bash_profile`. I could interrogate the shell for the user, but there's, you know, a weird chance that the shell is located in a different place on different computers, so it doesn't seem like a big deal to just make both files if they don't exist.